### PR TITLE
Add logo and technology icons

### DIFF
--- a/assets/icons/flutter.svg
+++ b/assets/icons/flutter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#02569B" />
+  <text x="32" y="40" font-size="32" font-family="Arial, sans-serif" font-weight="bold" fill="#fff" text-anchor="middle">F</text>
+</svg>

--- a/assets/icons/go.svg
+++ b/assets/icons/go.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#00ADD8" />
+  <text x="32" y="40" font-size="32" font-family="Arial, sans-serif" font-weight="bold" fill="#fff" text-anchor="middle">Go</text>
+</svg>

--- a/assets/icons/nextjs.svg
+++ b/assets/icons/nextjs.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#000" />
+  <text x="32" y="40" font-size="32" font-family="Arial, sans-serif" font-weight="bold" fill="#fff" text-anchor="middle">NX</text>
+</svg>

--- a/assets/icons/nodejs.svg
+++ b/assets/icons/nodejs.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#539E43" />
+  <text x="32" y="40" font-size="32" font-family="Arial, sans-serif" font-weight="bold" fill="#fff" text-anchor="middle">N</text>
+</svg>

--- a/assets/icons/react.svg
+++ b/assets/icons/react.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#61DAFB" />
+  <text x="32" y="40" font-size="32" font-family="Arial, sans-serif" font-weight="bold" fill="#000" text-anchor="middle">R</text>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e3c72" />
+      <stop offset="100%" stop-color="#2a5298" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" rx="20" fill="url(#grad)" />
+  <text x="50" y="62" font-size="50" font-family="'Courier New', Courier, monospace" font-weight="bold" fill="#fff" text-anchor="middle">nc</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
   <header class="hero fade-in">
-    <h1>nedcreative</h1>
+    <div class="logo-container">
+      <img src="assets/logo.svg" alt="nedcreative logo" class="logo" />
+      <h1>nedcreative</h1>
+    </div>
     <p>Solusi profesional untuk pengembangan aplikasi mobile, web, dan profil perusahaan</p>
   </header>
 
@@ -40,11 +43,11 @@
     <section id="tech" class="fade-in">
       <h2>Teknologi</h2>
       <ul class="tech-list">
-        <li class="slide-up">Golang</li>
-        <li class="slide-up">React</li>
-        <li class="slide-up">Node.js</li>
-        <li class="slide-up">Next.js</li>
-        <li class="slide-up">Flutter</li>
+        <li class="slide-up"><img src="assets/icons/go.svg" alt="Golang" />Golang</li>
+        <li class="slide-up"><img src="assets/icons/react.svg" alt="React" />React</li>
+        <li class="slide-up"><img src="assets/icons/nodejs.svg" alt="Node.js" />Node.js</li>
+        <li class="slide-up"><img src="assets/icons/nextjs.svg" alt="Next.js" />Next.js</li>
+        <li class="slide-up"><img src="assets/icons/flutter.svg" alt="Flutter" />Flutter</li>
       </ul>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -24,6 +24,17 @@ body {
   font-size: 3rem;
 }
 
+.logo-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.logo {
+  height: 50px;
+}
+
 .navbar ul {
   display: flex;
   justify-content: center;
@@ -85,6 +96,9 @@ h2 {
 }
 
 .tech-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   background: #232323;
   padding: 0.5rem 1rem;
   border-radius: 4px;
@@ -94,6 +108,11 @@ h2 {
 .tech-list li:hover {
   background: #2a5298;
   transform: translateY(-3px);
+}
+
+.tech-list img {
+  width: 24px;
+  height: 24px;
 }
 
 .projects {


### PR DESCRIPTION
## Summary
- add nedcreative logo and align it next to the site name
- display icons for Golang, React, Node.js, Next.js and Flutter
- style header logo and tech list for aligned visuals

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689482f9d27c8331b781f95ea00a70cf