### PR TITLE
fix: update pages upload artifact action

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
 


### PR DESCRIPTION
## Summary
- update GitHub Pages workflow to use actions/upload-pages-artifact@v3

## Testing
- `act -n -j deploy` *(fails: command not found)*
- `curl -L -o /tmp/act.tgz https://github.com/nektos/act/releases/download/v0.2.60/act_Linux_x86_64.tar.gz` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ab9e69b288331b0e96eb652f472d0